### PR TITLE
Fixed /lights JSON parsing

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -142,7 +142,7 @@ func (self *Bridge) GetAllLights() ([]*Light, error) {
 	defer response.Body.Close()
 
 	// deconstruct the json results
-	var results map[string]map[string]string
+	var results map[string]map[string]interface{}
 	err = json.NewDecoder(response.Body).Decode(&results)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (self *Bridge) GetAllLights() ([]*Light, error) {
 	// and convert them into lights
 	var lights []*Light
 	for id, params := range results {
-		light := Light{Id: id, Name: params["name"], bridge: self}
+		light := Light{Id: id, Name: params["name"].(string), bridge: self}
 		lights = append(lights, &light)
 	}
 


### PR DESCRIPTION
Hue's JSON responses have changed a bit with recent updates, and this caused go.hue to fail unmarshaling the response.
