### PR TITLE
Bug fix for json deserialization error in GetAllLights()

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -154,7 +154,7 @@ func (self *Bridge) GetAllLights() ([]*Light, error) {
 	defer response.Body.Close()
 
 	// deconstruct the json results
-	var results map[string]map[string]string
+	var results map[string]Light
 	err = json.NewDecoder(response.Body).Decode(&results)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (self *Bridge) GetAllLights() ([]*Light, error) {
 	// and convert them into lights
 	var lights []*Light
 	for id, params := range results {
-		light := Light{Id: id, Name: params["name"], bridge: self}
+		light := Light{Id: id, Name: params.Name, bridge: self}
 		lights = append(lights, &light)
 	}
 


### PR DESCRIPTION
The `(self *Bridge) GetAllLights()` func returned the following error "Error: json: cannot unmarshal object into Go value of type string" because the json returned:

``` json
{
    "1": {
        "state": {
            "on": false,
            "bri": 254,
            "alert": "none",
            "reachable": false
        },
        "type": "Dimmable light",
        "name": "Light 1",
        "modelid": "LWB004",
        "uniqueid": "7c:7c:7c:7c:7c:7c:7c:7c-7c",
        "swversion": "66012040",
        "pointsymbol": {
            "1": "none",
            "2": "none",
            "3": "none",
            "4": "none",
            "5": "none",
            "6": "none",
            "7": "none",
            "8": "none"
        }
    },
    "2": {
        "state": {
            "on": true,
            "bri": 254,
            "hue": 60139,
            "sat": 98,
            "effect": "none",
            "xy": [0.4968, 0.3456],
            "alert": "none",
            "colormode": "xy",
            "reachable": true
        },
        "type": "Color light",
        "name": "Light 2 - Bloom",
        "modelid": "LLC012",
        "uniqueid": "17:17:17:17:17:17:17:17-17",
        "swversion": "66009461",
        "pointsymbol": {
            "1": "none",
            "2": "none",
            "3": "none",
            "4": "none",
            "5": "none",
            "6": "none",
            "7": "none",
            "8": "none"
        }
    }
}
```

could not be deserialized. By reusing the Light struct during the deserialization this bug can be prevented.

The error occured under the following conditions:
- API Version: 1.5.0
- go version: go1.4 linux/amd64
